### PR TITLE
Updated documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,3 +43,9 @@ You then set these as environment variables in your jupyter notebook using the [
 %load_ext dotenv
 %dotenv
 ```
+
+### Using the AWS Glue docker image
+
+Some parts of this repository have been developed using the AWS Glue docker image (e.g. the [dummy database creator](../hudi_vs_iceberg/helpers/dummy_database_creator/)). AWS guidance on how to use this image can be found [here](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-libraries.html#develop-local-docker-image) and detailed instructions on its use in this repo can be found in each relevant subdirectory.
+
+Please note that when using AWS Vault you do not need to mount your local `.aws` directory. Rather you can pass your AWS environment variables when executing `docker run`.

--- a/docs/useful_resources.md
+++ b/docs/useful_resources.md
@@ -19,3 +19,5 @@
 - [Get started with Apache Hudi using AWS Glue](https://aws.amazon.com/blogs/big-data/part-1-get-started-with-apache-hudi-using-aws-glue-by-implementing-key-design-concepts/) How to get started with Apache Hudi on AWS glue and some available optimizations
 - [Native support for Apache Hudi, Delta Lake, and Apache Iceberg on AWS Glue](https://aws.amazon.com/blogs/big-data/part-1-getting-started-introducing-native-support-for-apache-hudi-delta-lake-and-apache-iceberg-on-aws-glue-for-apache-spark/)
 - [Using Iceberg and Athena](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html)
+- [AWS workshop demonstrating some of the main functionality of Athena with iceberg](https://catalog.us-east-1.prod.workshops.aws/workshops/9981f1a1-abdc-49b5-8387-cb01d238bb78/en-US/90-athena-acid)
+- [Documentation on developing with Glue locally using the official AWS Glue docker image](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-libraries.html#develop-local-docker-image)


### PR DESCRIPTION
Added additional resources:

- AWS Glue docker image docs link
- Athena with Iceberg workshop link

Updated contributing with high level guidance on the Glue docker image.