### PR TITLE
add tpcds generator

### DIFF
--- a/hudi_vs_iceberg/helpers/tpcds_generator/generate_tpcds.py
+++ b/hudi_vs_iceberg/helpers/tpcds_generator/generate_tpcds.py
@@ -1,0 +1,68 @@
+import boto3
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+
+glue_context = GlueContext(SparkContext())
+spark = glue_context.spark_session
+
+
+bucket_name = "sb-test-bucket-ireland"
+scale = 3000
+partitions = 36
+database_name = f"tpcds_{scale}"
+
+tables = [
+    # "call_center", "catalog_returns", 
+    # "catalog_page", "catalog_sales",
+    # "customer", "customer_address", "customer_demographics",
+    # "date_dim", "dbgen_version", "household_demographics",
+    # "income_band", "inventory", "item", "promotion", "reason",
+    # "ship_mode", "store", "store_returns", 
+    "store_sales",
+    # "time_dim", "warehouse",
+    # "web_page", "web_returns", "web_sales", "web_site"
+    ]
+
+
+## Create a database if not exists
+try:
+    glue = boto3.client('glue')
+    glue.create_database(DatabaseInput={'Name': database_name})
+    print(f"New database {database_name} created")
+except glue.exceptions.AlreadyExistsException:
+    print(f"Database {database_name} already exist")
+    
+
+for table in tables:
+    
+    ## Delete files in S3
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    bucket.objects.filter(Prefix=f"tpcds/scale={scale}/table={table}/").delete()
+    
+    ## Drop table in Glue Data Catalog
+    try:
+        glue = boto3.client('glue')
+        glue.delete_table(DatabaseName=database_name, Name=table)
+    except glue.exceptions.EntityNotFoundException:
+        print(f"Table {database_name}.{table} does not exist")
+    
+    # Create a DynamicFrame for `table`
+    dyf = glue_context.create_dynamic_frame.from_options(
+        connection_type="marketplace.spark",
+        connection_options={
+            "table": table,
+            "scale": scale,
+            "numPartitions": partitions,
+            "connectionName": "tpcds-connector-glue3"},
+        transformation_ctx="dyf")
+    
+    # Write the DynamicFrame to S3 and register the table.
+    sink = glue_context.getSink(
+        connection_type="s3", 
+        path=f"s3://{bucket_name}/tpcds/scale={scale}/table={table}/",
+        enableUpdateCatalog=True,
+        updateBehavior="UPDATE_IN_DATABASE")   
+    sink.setFormat("glueparquet")
+    sink.setCatalogInfo(catalogDatabase=database_name, catalogTableName=table)
+    sink.writeFrame(dyf)

--- a/hudi_vs_iceberg/helpers/tpcds_generator/update_tpcds.py
+++ b/hudi_vs_iceberg/helpers/tpcds_generator/update_tpcds.py
@@ -1,0 +1,48 @@
+import boto3
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+
+glue_context = GlueContext(SparkContext())
+spark = glue_context.spark_session
+
+
+bucket_name = "sb-test-bucket-ireland"
+scale = 3000
+partitions = 36
+database_name = f"tpcds_{scale}"
+source_table = "store_sales"
+path = f"tpcds_updates/scale={scale}/table={source_table}/"
+
+
+# number of days updated (there are 1823 days altogether)
+updated_days = [1]
+
+for update in updated_days:
+    
+    table = f"{source_table}_{update}"
+    
+    ## Delete files in S3
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    bucket.objects.filter(Prefix=f"{path}updated_days={update}/").delete()
+    
+    ## Drop table in Glue Data Catalog
+    try:
+        glue = boto3.client('glue')
+        glue.delete_table(DatabaseName=database_name, Name=table)
+    except glue.exceptions.EntityNotFoundException:
+        print(f"Table {database_name}.{table} does not exist")
+    
+    # Create a DynamicFrame for `table`
+    dyf = glue_context.create_dynamic_frame.from_catalog(database=database_name, table_name=source_table)
+    dyf_filter = dyf.filter( f=lambda x: x["ss_sold_date_sk"] in [2450816])
+
+    # Write the DynamicFrame to S3 and register the table.
+    sink = glue_context.getSink(
+        connection_type="s3", 
+        path=f"s3://{bucket_name}/{path}updated_days={update}/",
+        enableUpdateCatalog=True,
+        updateBehavior="UPDATE_IN_DATABASE")   
+    sink.setFormat("glueparquet")
+    sink.setCatalogInfo(catalogDatabase=database_name, catalogTableName=table)
+    sink.writeFrame(dyf_filter)


### PR DESCRIPTION
- PR to add glue jobs for generating tpcds data and udpates
- Note that I could convert table, scale and partitions into input variable but hard-coding for now
- The updates works by updating x number of days at a time. There are always 1823 days, and the idea is to update [1,10,100,1000] days 
- At the moment the updates job is hard-coded to update the first day only ("ss_sold_date_sk"] in [2450816])
- The updates job fails half way though because there is a schema mismatch so this needs to be fixed with the next PR
- I also need to. make sure the parquet files are compacted